### PR TITLE
Use metadata service to get public ip and removed use of deprecated template file data resoruce

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -2,12 +2,6 @@ data "aws_ssm_parameter" "ubuntu_ami" {
   name = "/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id"
 }
 
-data "template_file" "user_data" {
-  template = file("${path.module}/user_data.tpl")
-  vars = {
-    s3_bucket = "${aws_s3_bucket.openvpn_config_bucket.bucket}"
-  }
-}
 
 resource "aws_security_group" "openvpn_sg" {
   name = "openvpn_sg"
@@ -36,7 +30,9 @@ resource "aws_instance" "openvpn_ephemeral_ec2" {
   iam_instance_profile   = aws_iam_instance_profile.ec2_profile.name
   vpc_security_group_ids = [aws_security_group.openvpn_sg.id]
 
-  user_data = data.template_file.user_data.rendered
+  user_data = templatefile("${path.module}/user_data.tpl", {
+    s3_bucket = "${aws_s3_bucket.openvpn_config_bucket.bucket}"
+  })
 }
 
 resource "null_resource" "obtain_ovpn_file" {

--- a/user_data.tpl
+++ b/user_data.tpl
@@ -3,7 +3,7 @@ apt-get update
 apt-get install awscli -y
 curl -O https://raw.githubusercontent.com/angristan/openvpn-install/master/openvpn-install.sh
 chmod +x openvpn-install.sh
-APPROVE_INSTALL=y ENDPOINT=$(curl -4 ifconfig.co) APPROVE_IP=y IPV6_SUPPORT=n PORT_CHOICE=1 PROTOCOL_CHOICE=1 DNS=1 COMPRESSION_ENABLED=n  CUSTOMIZE_ENC=n CLIENT=openvpn PASS=1 ./openvpn-install.sh
+APPROVE_INSTALL=y ENDPOINT=$(curl http://169.254.169.254/latest/meta-data/public-ipv4) APPROVE_IP=y IPV6_SUPPORT=n PORT_CHOICE=1 PROTOCOL_CHOICE=1 DNS=1 COMPRESSION_ENABLED=n  CUSTOMIZE_ENC=n CLIENT=openvpn PASS=1 ./openvpn-install.sh
 mv /root/openvpn.ovpn /tmp/
 chown ubuntu: /tmp/openvpn.ovpn
 chmod 777 /tmp/openvpn.ovpn


### PR DESCRIPTION
Closes https://github.com/paulmarsicloud/terraform-aws-openvpn-ephemeral/issues/16

Also allows Apple Silicon People to use module (There was no darwin build for the template file provider).